### PR TITLE
Add isValidImageSrc utility function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@primoui/utils",
   "description": "A lightweight set of utilities",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "type": "module",
   "author": {

--- a/src/http/http.test.ts
+++ b/src/http/http.test.ts
@@ -8,6 +8,7 @@ import {
   getQueryParams,
   isExternalUrl,
   isLocalhostUrl,
+  isValidImageSrc,
   isValidUrl,
   joinUrlPaths,
   normalizeUrl,
@@ -472,5 +473,35 @@ describe("checkUrlAvailability", () => {
       successStatusBelow: 500,
     })
     expect(lenientResult).toBe(true)
+  })
+})
+
+describe("isValidImageSrc", () => {
+  it("validates absolute URLs", () => {
+    expect(isValidImageSrc("https://example.com/image.png")).toBe(true)
+    expect(isValidImageSrc("http://localhost/img.jpg")).toBe(true)
+    expect(isValidImageSrc("https://cdn.example.com/photos/pic.webp")).toBe(true)
+  })
+
+  it("validates relative paths", () => {
+    expect(isValidImageSrc("/images/photo.png")).toBe(true)
+    expect(isValidImageSrc("/img.jpg")).toBe(true)
+    expect(isValidImageSrc("/assets/icons/logo.svg")).toBe(true)
+  })
+
+  it("validates data URIs", () => {
+    expect(isValidImageSrc("data:image/png;base64,iVBOR")).toBe(true)
+  })
+
+  it("rejects falsy and invalid inputs", () => {
+    expect(isValidImageSrc(null)).toBe(false)
+    expect(isValidImageSrc(undefined)).toBe(false)
+    expect(isValidImageSrc("")).toBe(false)
+    expect(isValidImageSrc("not-a-url")).toBe(false)
+  })
+
+  it("handles edge cases", () => {
+    expect(isValidImageSrc("/")).toBe(false)
+    expect(isValidImageSrc("/ space")).toBe(false)
   })
 })

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -300,3 +300,14 @@ export const checkUrlAvailability = async (
   const getResponse = await makeRequest("GET")
   return getResponse !== null && getResponse.status < successStatusBelow
 }
+
+/**
+ * Checks if a string is a valid image source (relative path or absolute URL)
+ * @param src - The image source string to validate
+ * @returns True if the source is a valid relative path or absolute URL
+ */
+export const isValidImageSrc = (src?: string | null): src is string => {
+  if (!src) return false
+  if (/^\/\w/.test(src)) return true
+  try { return !!new URL(src) } catch { return false }
+}


### PR DESCRIPTION
Add a new utility function to validate image sources, supporting both relative paths and absolute URLs. Includes comprehensive test coverage with edge cases and type narrowing support.

**Changes:**
- Added `isValidImageSrc` function to `src/http/http.ts`
- Full test suite with 5 test cases in `src/http/http.test.ts`
- Version bumped to 1.4.3